### PR TITLE
Minor style changes in train schedule

### DIFF
--- a/src/components/TrainsView/TrainSchedule.vue
+++ b/src/components/TrainsView/TrainSchedule.vue
@@ -44,7 +44,8 @@
               </div>
 
               <!-- Routes  -->
-              <span
+              <div
+                class="info-scenery-change"
                 v-if="
                   stop.departureLine &&
                   scheduleStops[i + 1] != undefined &&
@@ -95,7 +96,7 @@
                     />
                   </span>
                 </div>
-              </span>
+              </div>
             </div>
           </div>
         </div>
@@ -542,6 +543,11 @@ $blinkStoppedAnim: 0.5s ease-in-out alternate infinite blinkStopped;
   img {
     height: 1.2em;
   }
+}
+
+.info-scenery-change {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .scenery-route {

--- a/src/components/TrainsView/TrainSchedule.vue
+++ b/src/components/TrainsView/TrainSchedule.vue
@@ -71,7 +71,7 @@
                 >
                   <span>{{ scheduleStops[i + 1].sceneryName }}</span>
                   <span v-if="stop.departureLineInfo?.routeTracks == 1"> &UpDownArrow;</span>
-                  <span v-else> &UpArrowDownArrow;</span>
+                  <span v-else> &DownArrowUpArrow;</span>
                 </div>
 
                 <div class="scenery-route">

--- a/src/components/TrainsView/TrainSchedule.vue
+++ b/src/components/TrainsView/TrainSchedule.vue
@@ -55,11 +55,15 @@
                   <span>{{ stop.departureLine }}</span>
                   <span v-if="stop.departureLineInfo">
                     | {{ stop.departureLineInfo.routeSpeed }}
-                    <span v-if="stop.departureLineInfo.isElectric">⚡</span>
+                    <span
+                      v-if="stop.departureLineInfo.isElectric"
+                      :title="$t('trains.electrified-tooltip')"
+                    >⚡</span>
                     <img
                       v-else
                       src="/images/icon-we4a.png"
                       :title="$t('trains.we4a-tooltip')"
+                      :alt="$t('trains.we4a-tooltip')"
                       width="10"
                     />
                   </span>
@@ -68,6 +72,9 @@
                 <div
                   v-if="stop.sceneryName != scheduleStops[i + 1]?.sceneryName"
                   class="scenery-change-name"
+                  :title="stop.departureLineInfo?.routeTracks == 1
+                    ? $t('trains.scenery-change-1-track')
+                    : $t('trains.scenery-change-2-track')"
                 >
                   <span>{{ scheduleStops[i + 1].sceneryName }}</span>
                   <span v-if="stop.departureLineInfo?.routeTracks == 1"> &UpDownArrow;</span>

--- a/src/components/TrainsView/TrainSchedule.vue
+++ b/src/components/TrainsView/TrainSchedule.vue
@@ -275,6 +275,7 @@ $stoppedClr: #f55f31;
 $haltClr: #f8bb36;
 
 $blinkAnim: 0.5s ease-in-out alternate infinite blink;
+$blinkStoppedAnim: 0.5s ease-in-out alternate infinite blinkStopped;
 
 @keyframes blink {
   from {
@@ -282,6 +283,15 @@ $blinkAnim: 0.5s ease-in-out alternate infinite blink;
   }
   to {
     border-color: $confirmedClr;
+  }
+}
+
+@keyframes blinkStopped {
+  from {
+    border-color: $barClr;
+  }
+  to {
+    border-color: $stoppedClr;
   }
 }
 
@@ -382,10 +392,15 @@ $blinkAnim: 0.5s ease-in-out alternate infinite blink;
   &[data-status='stopped'] {
     .progress > .node {
       border-color: $stoppedClr;
+      animation: $blinkStoppedAnim;
     }
 
-    .progress > .line_node {
-      border-color: $stoppedClr;
+    .progress > .line_node-top {
+      border-color: $confirmedClr;
+    }
+
+    .progress > .line_node-bottom {
+      border-color: $barClr;
     }
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -376,6 +376,9 @@
 
     "vmax-tooltip": "Maximum train speed based on rolling stock vehicles - braked weight is not included",
     "we4a-tooltip": "Non-electrified track",
+    "electrified-tooltip": "Electrified track",
+    "scenery-change-1-track": "Change of scenery on a single-track route",
+    "scenery-change-2-track": "Change of scenery on a double-track route",
 
     "delayed": "Delayed: ",
     "preponed": "Ahead of schedule: ",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -363,6 +363,9 @@
 
     "vmax-tooltip": "Maksymalna prędkość na podstawie pojazdów w składzie - nie bierze pod uwagę masy hamowania",
     "we4a-tooltip": "Szlak niezelektryfikowany",
+    "electrified-tooltip": "Szlak zelektryfikowany",
+    "scenery-change-1-track": "Zmiana scenerii na szlaku jednotorowym",
+    "scenery-change-2-track": "Zmiana scenerii na szlaku dwutorowym",
 
     "delayed": "Opóźniony: ",
     "preponed": "Przed czasem: ",


### PR DESCRIPTION
- Add blinking animation for trains stopped at station and change the color of the lines next to it:
  before: ![train-stopped-before](https://github.com/user-attachments/assets/ae60f0d1-ddce-487f-afcc-ec16630d79c9)
  after: ![train-stopped-after](https://github.com/user-attachments/assets/1267cf4a-be03-46b6-bd03-87c7e766015a)
- Replace `⇅` icon with `⇵` and add titles to the scenery change icons
- Add a margin around the scenery change info (not visible on the screenshot above)