### PR TITLE
v1.35.0 hotfixes

### DIFF
--- a/src/components/JournalView/JournalTimetables/EntryDetails.vue
+++ b/src/components/JournalView/JournalTimetables/EntryDetails.vue
@@ -48,7 +48,7 @@
 
           <ul>
             <li v-if="timetableDetails.twr">
-              <b class="text--primary">{{ $t('warnings.TWR') }} (TWR)</b>
+              <b class="text--primary">{{ $t('warnings.TWR') }}</b>
             </li>
 
             <li v-if="timetableDetails.skr">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -470,8 +470,8 @@
     "warnings": {
       "zags-loaded-twr": "TWR: 23UN1965, {0}x Zags",
       "zags-empty-tn": "TN: 23UN1965, {0}x Zags (empty)",
-      "zans-loaded-tn": "TN: 33UN1202, {0}x Zans",
-      "zans-empty-tn": "TN: 33UN1202, {0}x Zans (empty)",
+      "zans-loaded-tn": "TN: 30UN1202, {0}x Zans",
+      "zans-empty-tn": "TN: 30UN1202, {0}x Zans (empty)",
       "military-all-pn": "PN: military transport",
       "edk80-all-pn": "PN: EDK80 railway crane",
       "innofreight-all-pn": "PN: Innofreight C45 (exceeded gauge)"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -462,8 +462,8 @@
     "warnings": {
       "zags-loaded-twr": "TWR: 23UN1965, {0}x Zags",
       "zags-empty-tn": "TN: 23UN1965, {0}x Zags (próżne)",
-      "zans-loaded-tn": "TN: 33UN1202, {0}x Zans",
-      "zans-empty-tn": "TN: 33UN1202, {0}x Zans (próżne)",
+      "zans-loaded-tn": "TN: 30UN1202, {0}x Zans",
+      "zans-empty-tn": "TN: 30UN1202, {0}x Zans (próżne)",
       "military-all-pn": "PN: transport wojskowy",
       "edk80-all-pn": "PN: żuraw kolejowy EDK80",
       "innofreight-all-pn": "PN: Innofreight C45 (przekroczona skrajnia)"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -46,7 +46,7 @@
     "creator-message": "Twórca projektu Stacjownik"
   },
   "warnings": {
-    "TWR": "Pociąg z towarami niebezpiecznymi wysokiego ryzyka (TWR)",
+    "TWR": "Pociąg z towarami niebezpiecznymi wysokiego ryzyka",
     "SKR": "Pociąg z przekroczoną skrajnią",
     "PN": "Pociąg z przesyłkami nadzwyczajnymi",
     "TN": "Pociąg z towarami niebezpiecznymi",


### PR DESCRIPTION
- Changed 33UN1202 to 30UN1202 for cargo warnings in driver's helper
- Removed doubled "TWR" abbr. in timetable's journal 