### PR TITLE
v1.35.1 - hotfixes

### DIFF
--- a/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
+++ b/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
@@ -13,7 +13,7 @@
       >
         <span class="connection" v-if="i > 0">
           <span>{{ timetablePathDetails[i - 1].departure }}</span>
-          <span class="arrow"></span>
+          &gt;
           <span>{{ pathData.arrival }}</span>
         </span>
 

--- a/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
+++ b/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
@@ -2,7 +2,8 @@
   <div class="details-sceneries">
     <div class="g-separator"></div>
 
-    <h4>SCENERIE I SZLAKI:</h4>
+    <h4>{{ $t('journal.timetable-sceneries-title') }}</h4>
+
     <div class="path-list" v-if="timetablePathDetails">
       <div
         class="path-element"
@@ -23,7 +24,7 @@
             class="checkmark"
             v-if="pathData.isVisited"
             data-tooltip-type="BaseTooltip"
-            :data-tooltip-content="`${pathData.sceneryName}: sceneria odwiedzona`"
+            :data-tooltip-content="`${pathData.sceneryName}: ${$t('journal.timetable-scenery-visited')}`"
           >
             &checkmark;
           </span>

--- a/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsStops.vue
+++ b/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsStops.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="details-stops">
-    <h4>TRASA ROZKŁADU:</h4>
+    <h4>{{ $t('journal.timetable-stops-title') }}</h4>
+
     <ul class="stop-list">
       <li v-for="(stop, i) in timetableStops" :key="stop.stopName">
         <span class="stop-label" :data-confirmed="stop.isConfirmed">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -529,6 +529,9 @@
     "load-data": "Load further data...",
     "last-seen-at": "Last seen at",
     "currently-at": "Currently at",
+    "timetable-sceneries-title": "SCENERIES AND LINES:",
+    "timetable-scenery-visited": "scenery visited",
+    "timetable-stops-title": "TIMETABLE ROUTE:",
     "driver-stats": {
       "button": "DRIVER STATS",
       "title": "{name}'s DRIVER STATS",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -519,6 +519,9 @@
     "load-data": "Pobierz dalszą historię...",
     "last-seen-at": "Ostatnio widziany na: ",
     "currently-at": "Obecnie na scenerii: ",
+    "timetable-sceneries-title": "SCENERIE I SZLAKI:",
+    "timetable-scenery-visited": "sceneria odwiedzona",
+    "timetable-stops-title": "TRASA ROZKŁADU:",
     "driver-stats": {
       "button": "STAT. MASZYNISTY",
       "title": "STATYSTYKI MASZYNISTY {name}",


### PR DESCRIPTION
- Added missing translations
- Replaced unicode arrow with greater than sign in the details of journal timetables