### PR TITLE
v1.31.1 - hotfixes (2)

### DIFF
--- a/src/components/DriverView/DriverTrainSchedule.vue
+++ b/src/components/DriverView/DriverTrainSchedule.vue
@@ -107,7 +107,10 @@
                   "
                   class="scenery-change-name"
                 >
-                  <ScheduleSceneryInfo :scenery-name="stop.nextPointRef.sceneryName" />
+                  <ScheduleSceneryInfo
+                    :scenery-name="stop.nextPointRef.sceneryName"
+                    :region="train.region"
+                  />
                 </div>
 
                 <div

--- a/src/components/DriverView/ScheduleSceneryInfo.vue
+++ b/src/components/DriverView/ScheduleSceneryInfo.vue
@@ -41,6 +41,11 @@ const props = defineProps({
   sceneryName: {
     type: String,
     required: true
+  },
+
+  region: {
+    type: String,
+    required: true
   }
 });
 
@@ -49,7 +54,7 @@ const { t } = useI18n();
 
 const activeScenery = computed(() => {
   return apiStore.activeData?.activeSceneries
-    ?.filter((sc) => sc.stationName == props.sceneryName)
+    ?.filter((sc) => sc.stationName == props.sceneryName && sc.region == props.region)
     .sort((s1, s2) => s2.lastSeen - s1.lastSeen)[0];
 });
 </script>

--- a/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
+++ b/src/components/JournalView/JournalTimetables/TimetableDetails/DetailsSceneries.vue
@@ -20,14 +20,14 @@
         <span class="scenery-info">
           <span class="name">{{ pathData.sceneryName }}</span>
           <span class="hash">#{{ pathData.sceneryHash }}</span>
-          <span
-            class="checkmark"
+          <i
+            class="fa fa-check"
             v-if="pathData.isVisited"
             data-tooltip-type="BaseTooltip"
             :data-tooltip-content="`${pathData.sceneryName}: ${$t('journal.timetable-scenery-visited')}`"
+            aria-hidden="true"
           >
-            &checkmark;
-          </span>
+          </i>
         </span>
       </div>
     </div>
@@ -103,6 +103,7 @@ const timetablePathDetails = computed(() => {
 
 .scenery-info {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 0.25em;
 }
@@ -111,11 +112,8 @@ const timetablePathDetails = computed(() => {
   color: #aaa;
 }
 
-.scenery-info > .checkmark {
-  font-size: 1.5em;
-  line-height: 0.75em;
-  user-select: none;
-  -moz-user-select: none;
+.scenery-info > i {
+  color: lightgreen;
 }
 
 .path-element[data-visited='true'] > .scenery-info {


### PR DESCRIPTION
- Fixed displaying dispatcher of a scenery from a wrong server in the active train's timetable
- Switched to fa icon instead of HTML checkmark entity in the journal timetable details